### PR TITLE
Fixed same version upload to bintray causing 409 - CONFLICT.

### DIFF
--- a/.bintrayDescriptor.json
+++ b/.bintrayDescriptor.json
@@ -27,7 +27,10 @@
   "files": [
     {
       "includePattern": "build/libs/(.*)",
-      "uploadPattern": "org/k0r0pt/netutils/1.0.0/$1"
+      "uploadPattern": "org/k0r0pt/netutils/1.0.0/$1",
+      "matrixParams": {
+        "override": 1
+      }
     }
   ],
   "publish": true


### PR DESCRIPTION
* Added support for overriding jar files in bintray during upload.
