### PR TITLE
Added wait option to masscan output.

### DIFF
--- a/src/main/java/org/koreops/net/utils/IpInfoScraper.java
+++ b/src/main/java/org/koreops/net/utils/IpInfoScraper.java
@@ -90,7 +90,7 @@ public class IpInfoScraper {
     if (StringUtils.isEmpty(isp)) {
       isp = "Scan";
     }
-    StringBuilder ms = new StringBuilder("\n\n\nmasscan -p80,8080 --rate 1000000 --banners  -oJ " + isp + ".json ");
+    StringBuilder ms = new StringBuilder("\n\n\nmasscan -p80,8080 --rate 1000000 --banners --wait 60 -oJ " + isp + ".json ");
     String[] netRanges = this.getNetRanges();
 
     for (String ip : netRanges) {


### PR DESCRIPTION
* Added wait option to masscan output.

In case of large ipInfo.io networks, the default wait time wasn't enough to cover all hosts that have responded when being scanned with `masscan`. This option will ensure that they're not missed.